### PR TITLE
Try to import the python 3 urllib.parse, and fall back to urlparse

### DIFF
--- a/mock_services/service.py
+++ b/mock_services/service.py
@@ -2,7 +2,11 @@
 import json
 import logging
 import re
-import urlparse
+try:
+    from urllib import parse as urlparse
+except ImportError:
+    # Python 2
+    import urlparse
 
 import attr
 


### PR DESCRIPTION
With this patch, `mock_services` can be used with python 3.
