### PR TITLE
_real_send does not exist in MockerCore

### DIFF
--- a/mock_services/http_mock.py
+++ b/mock_services/http_mock.py
@@ -25,7 +25,7 @@ class HttpMock(MockerCore):
         self._adapter = _adapter
 
     def is_started(self):
-        return self._real_send
+        return self._last_send
 
     def set_allow_external(self, allow):
         """Set flag to authorize external calls when no matching mock.


### PR DESCRIPTION
I had failing tests because the missing _real_send attribute, maybe there was a change in requests-mock.
MockerCore uses _last_send to check if it already started so I changed it.

Relevant part of MockerCore:
```
    def start(self):
        """Start mocking requests.

        Install the adapter and the wrappers required to intercept requests.
        """
        if self._last_send:
            raise RuntimeError('Mocker has already been started')
```

Error I got before the change:
> ======================================================================
> ERROR: A profile is renamed.
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "/srv/www/pylxd/pylxd/tests/testing.py", line 28, in setUp
>     mock_services.start_http_mock()
>   File "/srv/www/pylxd/.tox/py3/lib/python3.6/site-packages/mock_services/helpers.py", line 15, in start_http_mock
>     if not http_mock.is_started():
>   File "/srv/www/pylxd/.tox/py3/lib/python3.6/site-packages/mock_services/http_mock.py", line 28, in is_started
>     return self._real_send
>   File "/srv/www/pylxd/.tox/py3/lib/python3.6/site-packages/requests_mock/mocker.py", line 132, in __getattr__
>     raise AttributeError(name)
> AttributeError: _real_send
